### PR TITLE
Update for laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "CrudResource"
     ],
     "require": {
-        "illuminate/support": "^7|^8|^9",
+        "illuminate/support": "^7|^8|^9|^10",
         "backpack/crud": "^5.0"
     },
     "require-dev": {

--- a/src/Fields/Select2Ajax.php
+++ b/src/Fields/Select2Ajax.php
@@ -49,4 +49,18 @@ final class Select2Ajax extends Field
 
         return $this;
     }
+
+    public function dependencies(array $dependencies): self
+    {
+        $this->props['dependencies'] = $dependencies;
+
+        return $this;
+    }
+
+    public function includeAllFormFields(bool $bool): self
+    {
+        $this->props['include_all_form_fields'] = $bool;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
### Description
1. Increase interoperability version to 10 for "illuminate support" package
2. Add two property setters: dependencies, includeAllFormFields to support Select2Ajax field