### PR TITLE
Add null as parameter type in default method of fields.

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -121,7 +121,7 @@ abstract class Field
     /**
      * Default value for the field.
      */
-    public function default(string | bool | int $value): self
+    public function default(string | bool | int | null $value): self
     {
         $this->default = $value;
 


### PR DESCRIPTION
## Description
 Some time we need  to add default value in edit page (Custom field). 
But, the `default` value in create page is null. So, allowing null in `default` method enhances usability. 