### PR TITLE
Fix option not found exception for custom field

### DIFF
--- a/src/Fields/Custom.php
+++ b/src/Fields/Custom.php
@@ -19,7 +19,7 @@ final class Custom extends Field
      */
     public function options(array $options = []): self
     {
-        $this->props = array_merge($this->props, $options);
+        $this->props['options'] = $options;
 
         return $this;
     }


### PR DESCRIPTION
## Description
- Fix option not found exception for custom field. (The previous code was not adding the option `attribute` when using a custom field that requires `options`)

### Problem
If we use below code,
``` 
Custom::make('type')
      ->type('select_from_array')
      ->options(['one' => 'One', 'two' => 'Two']),

````
    It throws the error:   Undefined array key "options".

### Solution

To solve the problem we propose the change.

Also, see the [documentation](https://backpackforlaravel.com/docs/5.x/crud-fields#select_from_array), of a field where option is required.
            